### PR TITLE
Refactor to avoid abstract type by definition juggling

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,22 @@
+using BenchmarkTools, ConcurrentHashTries
+
+const SUITE = BenchmarkGroup()
+
+SUITE["insert"] = BenchmarkGroup()
+
+struct Collide{T}
+    x::T
+end
+Base.hash(::Collide, h::UInt) = zero(h)
+
+function one_hundred_inserts(T, f)
+    c = Ctrie{T,Int}()
+    for i = 1:100
+        insert(c, f(i), i)
+    end
+    return c
+end
+
+SUITE["insert"]["integers"] = @benchmarkable one_hundred_inserts($Int, $identity)
+SUITE["insert"]["integers_hash_colliding"] = @benchmarkable one_hundred_inserts($(Collide{Int}), $Collide)
+SUITE["insert"]["integers_same_slot"] = @benchmarkable one_hundred_inserts($Int, $(Returns(1)))

--- a/src/ConcurrentHashTries.jl
+++ b/src/ConcurrentHashTries.jl
@@ -35,11 +35,9 @@ struct LNode{K,V}
     next::Union{Nothing,LNode{K,V}}
 end
 
-# This is analogous to HMAT{K,V} from https://github.com/vchuravy/HashArrayMappedTries.jl,
-# except we allow INode's in the vector too.
+# This is analogous to HMAT{K,V} from https://github.com/vchuravy/HashArrayMappedTries.jl
 struct CNode{K,V}
-    # We can't use `MainNode{K,V}` yet since we need CNode which we are defining here.
-    # But we can self-reference CNode, so let's inline the definition manually
+    # We can't use `INode{K,V}` yet, so we manually inline its definition
     data::Vector{Union{SNode{K,V}, ParametricINode{Union{TNode{K,V}, CNode{K,V}, LNode{K,V}}}}}
     bitmap::BITMAP
 end

--- a/src/ConcurrentHashTries.jl
+++ b/src/ConcurrentHashTries.jl
@@ -9,17 +9,19 @@ export lookup, insert
 
 # This is a translation of Fig. 3 of "Concurrent Tries with Efficient Non-Blocking Snapshots" by Prokopec et al
 
-# Using an abstract type instead of a union, since
-# julia doesn't have mutually recursive types, xref
-# https://github.com/JuliaLang/julia/issues/269
-abstract type Branch{K,V} end
-
 const BITMAP = UInt32
 const W = 5
 
 struct Gen end
 
-struct SNode{K,V} <: Branch{K,V}
+mutable struct ParametricINode{M}
+    # We can't use `MainNode{K,V}` yet since we don't have the other types defined yet.
+    # Leave parametric for now.
+    @atomic main::M
+    const gen::Gen
+end
+
+struct SNode{K,V}
     key::K
     val::V
 end
@@ -36,18 +38,22 @@ end
 # This is analogous to HMAT{K,V} from https://github.com/vchuravy/HashArrayMappedTries.jl,
 # except we allow INode's in the vector too.
 struct CNode{K,V}
-    data::Vector{Branch{K,V}}
+    # We can't use `MainNode{K,V}` yet since we need CNode which we are defining here.
+    # But we can self-reference CNode, so let's inline the definition manually
+    data::Vector{Union{SNode{K,V}, ParametricINode{Union{TNode{K,V}, CNode{K,V}, LNode{K,V}}}}}
     bitmap::BITMAP
 end
 
-CNode{K,V}() where {K,V} = CNode(Vector{Branch{K,V}}(undef, 0), zero(BITMAP))
-
+# Now we can finally define our MainNode
 MainNode{K,V} = Union{CNode{K,V},TNode{K,V},LNode{K,V}}
 
-mutable struct INode{K,V} <: Branch{K,V}
-    @atomic main::MainNode{K,V}
-    const gen::Gen
-end
+# And use it to define proper INode's
+INode{K,V} = ParametricINode{MainNode{K,V}}
+
+Branch{K,V} = Union{INode{K,V}, SNode{K,V}}
+
+CNode{K,V}() where {K,V} = CNode(Vector{Branch{K,V}}(undef, 0), zero(BITMAP))
+
 
 struct Ctrie{K,V}
     root::INode{K,V}


### PR DESCRIPTION
Alternative to #2 and #3: this is very similar to main, but by juggling the type definitions appropriately we can avoid the abstract branch type.